### PR TITLE
ci: 升级为 GitHub Actions 现代 Pages 部署模式

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,18 +3,30 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - main  # 或者指定其他分支，根据实际情况修改
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -24,8 +36,11 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist 
+          path: ./dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

传统 `peaceiris/actions-gh-pages` 通过覆盖 `gh-pages` 分支部署，每次 CI 构建时缺少 `CNAME` 文件，会冲掉 GitHub 为自定义域名生成的配置，导致部署后域名失效。

## 变更

- 移除 `peaceiris/actions-gh-pages@v3`
- 添加 `permissions`：`contents: read`、`pages: write`、`id-token: write`
- 使用官方 `actions/upload-pages-artifact@v3` 上传构建产物
- 使用官方 `actions/deploy-pages@v4` 部署到 GitHub Pages
- 添加 `concurrency` 与 `github-pages` environment，避免并发部署冲突

## 合并后需手动操作

在仓库 **Settings → Pages → Build and deployment → Source** 中：

1. 将部署源从 **Deploy from a branch** 改为 **GitHub Actions**
2. 重新绑定并保存一次自定义域名

此后每次部署不会再覆盖域名配置。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef25d1cc-2e2a-4495-9cfa-a65cb3006828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef25d1cc-2e2a-4495-9cfa-a65cb3006828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

